### PR TITLE
Fixed wrong log path

### DIFF
--- a/scripts/start-stop-status.sh
+++ b/scripts/start-stop-status.sh
@@ -64,7 +64,7 @@ case $1 in
         ;;
 
   log)
-    echo "${SYNOPKG_PKGDEST}/logs/openhab.log"
+    echo "${SYNOPKG_PKGDEST}/userdata/logs/openhab.log"
     exit 0
   ;;
 esac


### PR DESCRIPTION
The protocol in the DSM package manager did not show the log, because the log path was wrong. After correcting it, it shows up (tested on Synology DS214Play with DSM 6.0.1-7393 Update 1).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-syno-spk/28)
<!-- Reviewable:end -->
