### PR TITLE
fix error with checking if port is already used

### DIFF
--- a/scripts/start-stop-status.sh
+++ b/scripts/start-stop-status.sh
@@ -60,7 +60,7 @@ case $1 in
     fi
     
     #Are the port already used?
-    if netstat -tlpn | grep ${SYNOPKG_PKGPORT}; then
+    if netstat -tlpn | grep :${SYNOPKG_PKGPORT}; then
       echo "  Port ${SYNOPKG_PKGPORT} already in use." >>$LOG
       exit 1
     fi


### PR DESCRIPTION
If there is an open port which partially matches one of the desired ports the check in start-stop-status script will fail.

E.g. if some process has port 18080 opened the search if port 8080 is already used will show that it is already used, but in this case it's not true.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-syno-spk/151)
<!-- Reviewable:end -->
