### PR TITLE
Fixes #146: Use 7zip in restore script #150

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.project
+*.spk

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -9,6 +9,7 @@ find ${LOG} -mtime +1 -type f -delete
 echo "#### S T A R T  -  o p e n H A B  S P K ####" >>$LOG
 echo "$(date +%Y-%m-%d:%H:%M:%S)" >>$LOG
 echo "" >>$LOG
+echo "SYNOPKG_PKGINST_TEMP_DIR=${SYNOPKG_PKGINST_TEMP_DIR}" >>$LOG
 
 echo "Set instance variables..." >>$LOG
 
@@ -17,7 +18,6 @@ BASE_PATH='https://dl.bintray.com/openhab/mvn/org/openhab/distro/openhab'
 wget -nv --no-check-certificate --output-document='metadata.xml' "$BASE_PATH/maven-metadata.xml"
 OPENHAB_RELEASE="$(grep -E '<release>(.*)</release>' metadata.xml | cut -d '>' -f 2 | cut -d '<' -f 1)"
 DOWNLOAD_FILE1="openhab-$OPENHAB_RELEASE.zip"
-
 
 # Add more files by separating them using spaces
 INSTALL_FILES="$BASE_PATH/$OPENHAB_RELEASE/$DOWNLOAD_FILE1"
@@ -43,14 +43,13 @@ echo "  Z-Wave:    ${pkgwizard_zwave}"  >>$LOG
 
 if [ "${pkgwizard_public_std}" == "true" ]; then
   SHARE_FOLDER="$(synoshare --get public | grep Path | awk -F[ '{print $2}' | awk -F] '{print $1}')"
-  OH_FOLDER="${SHARE_FOLDER}/${SYNOPKG_PKGNAME}"
 elif [ "${pkgwizard_public_shome}"  == "true" ]; then
   SHARE_FOLDER="$(synoshare --get smarthome | grep Path | awk -F[ '{print $2}' | awk -F] '{print $1}')"
-  OH_FOLDER="${SHARE_FOLDER}/${SYNOPKG_PKGNAME}"
 else
   SHARE_FOLDER="/var/services/homes"
-  OH_FOLDER="${SHARE_FOLDER}/${DAEMON_USER}"
 fi
+
+OH_FOLDER="${SYNOPKG_PKGDEST}/${SYNOPKG_PKGNAME}"
 
 if [ ! -z "${pkgwizard_txt_port}" ]; then
   echo "  port:    ${pkgwizard_txt_port}" >>$LOG
@@ -198,7 +197,6 @@ postinst ()
   echo "    TempFolder= $(pwd)" >> $LOG
   echo "    content= $(ls -lrt)" >>$LOG
   echo "    Extract ${DOWNLOAD_FILE1}" >>$LOG
-  
   if [ -e /usr/bin/7z ]; then
     7z x ${TEMP_FOLDER}/${DOWNLOAD_FILE1} -o${EXTRACTED_FOLDER}
   else

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -18,6 +18,7 @@ wget -nv --no-check-certificate --output-document='metadata.xml' "$BASE_PATH/mav
 OPENHAB_RELEASE="$(grep -E '<release>(.*)</release>' metadata.xml | cut -d '>' -f 2 | cut -d '<' -f 1)"
 DOWNLOAD_FILE1="openhab-$OPENHAB_RELEASE.zip"
 
+
 # Add more files by separating them using spaces
 INSTALL_FILES="$BASE_PATH/$OPENHAB_RELEASE/$DOWNLOAD_FILE1"
 
@@ -194,7 +195,10 @@ postinst ()
   #extract main archive
   echo "  Install new version" >>$LOG
   cd ${TEMP_FOLDER}
+  echo "    TempFolder= $(pwd)" >> $LOG
+  echo "    content= $(ls -lrt)" >>$LOG
   echo "    Extract ${DOWNLOAD_FILE1}" >>$LOG
+  
   if [ -e /usr/bin/7z ]; then
     7z x ${TEMP_FOLDER}/${DOWNLOAD_FILE1} -o${EXTRACTED_FOLDER}
   else
@@ -211,6 +215,9 @@ postinst ()
   mv ${TEMP_FOLDER}/${EXTRACTED_FOLDER}/* ${SYNOPKG_PKGDEST}
   rmdir ${TEMP_FOLDER}/${EXTRACTED_FOLDER}
   chmod +x ${SYNOPKG_PKGDEST}/${ENGINE_SCRIPT}
+  
+  echo "    copy specific restore file from packages" >>$LOG
+  cp /var/packages/${SYNOPKG_PKGNAME}/scripts/restore ${SYNOPKG_PKGDEST}/runtime/bin
 
   # configurate new port for package center
   sed -i 's/^adminport=.*$/adminport="'${pkgwizard_txt_port}'"/g' /var/packages/${SYNOPKG_PKGNAME}/INFO

--- a/scripts/restore
+++ b/scripts/restore
@@ -79,7 +79,7 @@ setup "$InputFile"
 ## Extract zip file
 echo "Extracting zip file to temporary folder."
 
-7z x "$InputFile" -o"TempDir" -y || {
+7z x "$InputFile" -o"$TempDir" -y || {
   echo "Unable to unzip $InputFile, Aborting..." >&2
   exit 1
 }


### PR DESCRIPTION
restore file wasn't taken in account. (keep original openhab file)
copy the file now to overwrite them in script installer.sh
7z fix wasn't finished: line 82, miss $ and the file was in windows format

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-syno-spk/175)
<!-- Reviewable:end -->
