### PR TITLE
OpenJDK: Adding Java 11 into our package

### DIFF
--- a/scripts/start-stop-status.sh
+++ b/scripts/start-stop-status.sh
@@ -83,7 +83,7 @@ case $1 in
     
     #start OpenHAB runtime in background mode
     echo "  call start.sh." >>$LOG
-    su - ${DAEMON_USER} -s /bin/sh -c "cd ${SYNOPKG_PKGDEST} && ./${ENGINE_SCRIPT} &"   
+    su - ${DAEMON_USER} -s /bin/sh -c "cd ${SYNOPKG_PKGDEST} && PATH=${SYNOPKG_PKGDEST}/OpenJDK/bin:${PATH} && ./${ENGINE_SCRIPT} &"
     if [ $? -ne 0 ]; then echo "  FAILED (su)" >>$LOG; exit 1; fi
     wait_for_status 0 30
     rm -f ${PIDFILE}


### PR DESCRIPTION
Synology dropped any Java package from their software repository in DSM. It is unknown whether they will ever add Java at all.
As OpenHAB itself recommends specific version(s) of Java for installation, I'm adding this feature not only to get independent of Synology, but also to get back full control over our installation.

This work has not been tested. Some corrections might follow.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com> (github: thopiekar)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-syno-spk/176)
<!-- Reviewable:end -->
